### PR TITLE
Fix #3 Parse input stream from socket or serial for complete KISS frames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
+        "kiss-tnc": "^1.1.0",
         "serialport": "latest"
       },
       "devDependencies": {
@@ -296,6 +297,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/kiss-tnc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/kiss-tnc/-/kiss-tnc-1.1.0.tgz",
+      "integrity": "sha512-rRPCzjIkwCVafC6l59jttpWB2S8POi26Sj2T6W3laHeUNRNBO3N6oGNirvxYICPEPOlE6aIEVZpILoebHb9cYQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/taylorsreid/jsax25/issues"
   },
   "dependencies": {
+    "kiss-tnc": "^1.1.0",
     "serialport": "latest"
   },
   "homepage": "https://github.com/taylorsreid/jsax25#readme",

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -39,6 +39,8 @@ export interface mutableModulo {
     set modulo(modulo: 8 | 128)
 }
 
+export const DEFAULT_SERIAL_BAUD = 19200
+
 export function validateCallsign(callsign: string) {
     if (callsign.length < 1 || callsign.length > 6) {
         throw new Error(`'${callsign}' is not a valid callsign. Callsigns must have a length from 1 to 6 characters inclusive.`)
@@ -55,6 +57,22 @@ export function validatePid(pid: number) {
     if (pid < 0) {
         throw new Error(`${pid} is not a valid PID. PIDs must be greater than or equal to 0.`)
     }
+}
+
+export function validateBaudRate(bd: unknown): number {
+    if ([null, undefined].includes(bd as null | undefined)) {
+        return DEFAULT_SERIAL_BAUD
+    }
+
+    const bdNumber = Number(bd)
+
+    // TODO: We could potentially check the baud rate against the list of standard ones,
+    // but for now it's probably fine to must make sure it's a positive integer
+    if (Number.isSafeInteger(bdNumber) && bdNumber > 0) {
+        return bdNumber
+    }
+
+    throw new Error(`Invalid baud rate: ${bd}`);
 }
 
 export function resetRepeaters(repeaters: Repeater[] | undefined): Repeater[] {


### PR DESCRIPTION
A couple of changes:
* Created a default baud rate variable in `./misc`. I noticed that there were a couple of defaulting baud rates... was that intentional?
* I added a package called [`kiss-tnc`](https://www.npmjs.com/package/kiss-tnc) (yes I wrote it, sorry) that will interpret raw data coming over a connection and ensure that an entire KISS frame (from FEND to FEND) is emitted in its entirety, as well as escaping the contents. Has this been any kind of issue in your testing?
* I slightly modified the surface of `KissConnection`. I made `.connection` read-only and a generic Duplex stream, and made `setConnection` a method that functions similar to the setter that you had before.

I'd love to find out more about your testing strategy, as well as any hardware/software combinations you've used for end-to-end testing! Thanks.